### PR TITLE
Improved __str__ for Tensor, Operator and OperatorSum

### DIFF
--- a/matchingtools/core.py
+++ b/matchingtools/core.py
@@ -393,7 +393,7 @@ class Operator(Conjugable, Convertible, Differentiable, Functional):
             try:
                 from sympy import nsimplify
                 coefficient_str = str(nsimplify(self.coefficient))
-            except ModuleNotFoundError:
+            except ImportError:
                 coefficient_str = str(self.coefficient)
 
         final_str = coefficient_str


### PR DESCRIPTION
- Assign a unique str representation to indices, as specified in #19.
- Split lines (at product and sum signs) to be smaller than 80 characters.
- Use `sympy.nsimplify` for operator coefficients if possible.